### PR TITLE
Add FastAPI research assistant service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+venv/
+.env
+.env.*
+.envrc
+.idea/
+.vscode/
+.DS_Store
+data/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,11 @@
+"""Application package for the research assistant FastAPI service."""
+
+__all__ = [
+    "config",
+    "embedding",
+    "ingestion",
+    "main",
+    "models",
+    "text_extraction",
+    "vector_store",
+]

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,25 @@
+"""Configuration constants for the research assistant service."""
+from pathlib import Path
+
+# Base directories
+DATA_DIR = Path("data")
+RAW_DATA_DIR = DATA_DIR / "raw"
+INDEX_DIR = DATA_DIR / "indexes"
+
+# File paths for vector store artifacts
+FAISS_INDEX_PATH = INDEX_DIR / "default.index"
+METADATA_PATH = INDEX_DIR / "default_metadata.json"
+
+# Embedding model configuration
+EMBEDDING_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+CHUNK_SIZE = 500
+CHUNK_OVERLAP = 100
+
+# Google Drive configuration placeholders
+# Update this path to point to your service account JSON credentials file.
+GOOGLE_SERVICE_ACCOUNT_FILE = Path("config/service_account.json")
+GOOGLE_DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+
+# Ensure directories exist when the module is imported.
+for directory in (DATA_DIR, RAW_DATA_DIR, INDEX_DIR):
+    directory.mkdir(parents=True, exist_ok=True)

--- a/app/embedding.py
+++ b/app/embedding.py
@@ -1,0 +1,54 @@
+"""Embedding utilities powered by Sentence Transformers."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Iterable
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+class EmbeddingService:
+    """Wrapper around a ``SentenceTransformer`` model."""
+
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        self._model = SentenceTransformer(model_name)
+
+    @property
+    def dimension(self) -> int:
+        """Return the dimensionality of the embeddings produced by the model."""
+        return int(self._model.get_sentence_embedding_dimension())
+
+    @property
+    def model(self) -> SentenceTransformer:
+        return self._model
+
+    def embed_documents(self, texts: Iterable[str]) -> np.ndarray:
+        """Compute embeddings for an iterable of texts."""
+        texts = list(texts)
+        if not texts:
+            return np.empty((0, self.dimension), dtype="float32")
+        vectors = self._model.encode(
+            texts,
+            convert_to_numpy=True,
+            show_progress_bar=False,
+            normalize_embeddings=True,
+        )
+        return np.asarray(vectors, dtype="float32")
+
+    def embed_query(self, query: str) -> np.ndarray:
+        """Compute an embedding vector for a single query."""
+        vector = self._model.encode(
+            [query],
+            convert_to_numpy=True,
+            show_progress_bar=False,
+            normalize_embeddings=True,
+        )
+        return np.asarray(vector[0], dtype="float32")
+
+
+@lru_cache(maxsize=1)
+def get_embedding_service(model_name: str) -> EmbeddingService:
+    """Cached factory for :class:`EmbeddingService` instances."""
+    return EmbeddingService(model_name)

--- a/app/ingestion.py
+++ b/app/ingestion.py
@@ -1,0 +1,146 @@
+"""Document ingestion utilities for the research assistant."""
+from __future__ import annotations
+
+import io
+import importlib
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from . import config
+from .models import DocumentChunk
+from .text_extraction import extract_text, chunk_text, UnsupportedDocumentTypeError
+
+
+class GoogleDriveIngestionError(RuntimeError):
+    """Raised when Google Drive ingestion fails."""
+
+
+def _build_drive_service():
+    """Instantiate a Google Drive service client using a service account.
+
+    This function relies on ``googleapiclient`` and ``google.oauth2`` packages. Ensure
+    they are installed and that ``config.GOOGLE_SERVICE_ACCOUNT_FILE`` points to a valid
+    service account JSON credential file with access to the target Drive resources.
+    """
+
+    discovery = importlib.import_module("googleapiclient.discovery")
+    service_account = importlib.import_module("google.oauth2.service_account")
+
+    credentials = service_account.Credentials.from_service_account_file(
+        str(config.GOOGLE_SERVICE_ACCOUNT_FILE), scopes=config.GOOGLE_DRIVE_SCOPES
+    )
+    return discovery.build("drive", "v3", credentials=credentials)
+
+
+def _download_drive_file(service, file_info: Dict[str, str], destination: Path) -> Path:
+    """Download a single file from Google Drive to ``destination``."""
+    http = importlib.import_module("googleapiclient.http")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    file_id = file_info["id"]
+    file_name = file_info["name"]
+    mime_type = file_info.get("mimeType", "")
+
+    request = None
+    if mime_type.startswith("application/vnd.google-apps"):
+        # Export native Google Docs formats to PDF by default.
+        export_mime_type = "application/pdf"
+        request = service.files().export_media(fileId=file_id, mimeType=export_mime_type)
+        file_name = f"{file_name}.pdf" if not file_name.lower().endswith(".pdf") else file_name
+    else:
+        request = service.files().get_media(fileId=file_id)
+
+    buffer = io.BytesIO()
+    downloader = http.MediaIoBaseDownload(buffer, request)
+    done = False
+    while not done:
+        _, done = downloader.next_chunk()
+
+    output_path = destination / file_name
+    with output_path.open("wb") as f:
+        f.write(buffer.getvalue())
+    return output_path
+
+
+def download_google_drive_folder(folder_id: str, destination: Path) -> List[Path]:
+    """Download all files within a Google Drive folder recursively.
+
+    Parameters
+    ----------
+    folder_id:
+        Identifier of the Google Drive folder to download.
+    destination:
+        Local directory where files should be saved.
+    """
+    service = _build_drive_service()
+    downloaded: List[Path] = []
+
+    def _walk_folder(current_folder_id: str, current_destination: Path) -> None:
+        query = f"'{current_folder_id}' in parents and trashed = false"
+        page_token = None
+        while True:
+            response = (
+                service.files()
+                .list(
+                    q=query,
+                    fields="nextPageToken, files(id, name, mimeType)",
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            for file_info in response.get("files", []):
+                mime_type = file_info.get("mimeType", "")
+                if mime_type == "application/vnd.google-apps.folder":
+                    sub_destination = current_destination / file_info["name"]
+                    _walk_folder(file_info["id"], sub_destination)
+                else:
+                    path = _download_drive_file(service, file_info, current_destination)
+                    downloaded.append(path)
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+    try:
+        _walk_folder(folder_id, destination)
+    except Exception as exc:  # noqa: BLE001 - propagate as custom error
+        raise GoogleDriveIngestionError("Failed to download Google Drive folder") from exc
+
+    return downloaded
+
+
+def build_document_chunks(files: Iterable[Path]) -> List[DocumentChunk]:
+    """Extract and chunk text content from the provided files."""
+    chunks: List[DocumentChunk] = []
+    for path in files:
+        try:
+            text = extract_text(path)
+        except UnsupportedDocumentTypeError:
+            continue
+        except FileNotFoundError:
+            continue
+        document_chunks = chunk_text(text)
+        for index, content in enumerate(document_chunks):
+            metadata = {
+                "source_path": str(path),
+                "document_name": path.name,
+                "chunk_index": index,
+            }
+            chunks.append(DocumentChunk(content=content, metadata=metadata))
+    return chunks
+
+
+def ingest_from_google_drive(folder_id: str) -> List[DocumentChunk]:
+    """Download a Google Drive folder and return document chunks."""
+    destination = config.RAW_DATA_DIR / folder_id
+    files = download_google_drive_folder(folder_id, destination)
+    return build_document_chunks(files)
+
+
+def ingest_from_notion_placeholder(*_: str) -> List[DocumentChunk]:
+    """Placeholder for future Notion ingestion support."""
+    return []
+
+
+def ingest_from_canva_placeholder(*_: str) -> List[DocumentChunk]:
+    """Placeholder for future Canva ingestion support."""
+    return []

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,103 @@
+"""FastAPI application exposing research assistant capabilities."""
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+
+from . import config
+from .embedding import get_embedding_service
+from .ingestion import (
+    GoogleDriveIngestionError,
+    ingest_from_canva_placeholder,
+    ingest_from_google_drive,
+    ingest_from_notion_placeholder,
+)
+from .models import (
+    CanvaIngestRequest,
+    GoogleDriveIngestRequest,
+    NotionIngestRequest,
+    QueryRequest,
+    QueryResponse,
+    QueryResult,
+)
+from .vector_store import FaissVectorStore, VectorStoreError, get_vector_store
+
+app = FastAPI(
+    title="Research Assistant API",
+    version="0.1.0",
+    description="Ingests documents into a FAISS vector store and provides semantic search.",
+)
+
+_embedding_service = None
+_vector_store: FaissVectorStore | None = None
+
+
+@app.on_event("startup")
+def startup_event() -> None:
+    """Initialize the embedding service and FAISS vector store."""
+    global _embedding_service, _vector_store  # noqa: PLW0603
+    _embedding_service = get_embedding_service(config.EMBEDDING_MODEL_NAME)
+    _vector_store = get_vector_store(_embedding_service.dimension)
+
+
+@app.post("/ingest/google-drive")
+def ingest_google_drive_endpoint(request: GoogleDriveIngestRequest) -> Dict[str, int]:
+    """Ingest documents from a Google Drive folder into the vector store."""
+    if _embedding_service is None or _vector_store is None:
+        raise HTTPException(status_code=503, detail="Embedding service not initialized.")
+
+    try:
+        chunks = ingest_from_google_drive(request.folder_id)
+    except GoogleDriveIngestionError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    embeddings = _embedding_service.embed_documents(chunk.content for chunk in chunks)
+    try:
+        _vector_store.add_documents(embeddings, chunks)
+    except VectorStoreError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return {"chunks_ingested": len(chunks)}
+
+
+@app.post("/ingest/notion")
+def ingest_notion_endpoint(_: NotionIngestRequest) -> Dict[str, str]:
+    """Placeholder endpoint for Notion ingestion."""
+    ingest_from_notion_placeholder()
+    return {"status": "Notion ingestion is not yet implemented."}
+
+
+@app.post("/ingest/canva")
+def ingest_canva_endpoint(_: CanvaIngestRequest) -> Dict[str, str]:
+    """Placeholder endpoint for Canva ingestion."""
+    ingest_from_canva_placeholder()
+    return {"status": "Canva ingestion is not yet implemented."}
+
+
+@app.post("/query", response_model=QueryResponse)
+def query_endpoint(request: QueryRequest) -> QueryResponse:
+    """Perform a semantic search against the FAISS vector store."""
+    if _embedding_service is None or _vector_store is None:
+        raise HTTPException(status_code=503, detail="Embedding service not initialized.")
+
+    if not request.query:
+        raise HTTPException(status_code=400, detail="Query text must be provided.")
+
+    query_embedding = _embedding_service.embed_query(request.query)
+    records = _vector_store.search(query_embedding, request.top_k)
+    results = [
+        QueryResult(
+            content=record.get("content", ""),
+            score=record.get("score", 0.0),
+            metadata=record.get("metadata", {}),
+        )
+        for record in records
+    ]
+    return QueryResponse(results=results)
+
+
+@app.get("/")
+def root() -> Dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "ok"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,60 @@
+"""Data models for the research assistant application."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+@dataclass
+class DocumentChunk:
+    """A chunk of text extracted from a source document."""
+
+    content: str
+    metadata: Dict[str, Any]
+
+
+class GoogleDriveIngestRequest(BaseModel):
+    """Request payload for Google Drive ingestion."""
+
+    folder_id: str = Field(..., description="Google Drive folder ID to ingest")
+
+
+class NotionIngestRequest(BaseModel):
+    """Placeholder request payload for Notion ingestion."""
+
+    workspace_id: Optional[str] = Field(
+        None,
+        description="Notion workspace identifier (placeholder).",
+    )
+
+
+class CanvaIngestRequest(BaseModel):
+    """Placeholder request payload for Canva ingestion."""
+
+    brand_kit_id: Optional[str] = Field(
+        None,
+        description="Canva brand kit identifier (placeholder).",
+    )
+
+
+class QueryRequest(BaseModel):
+    """Request payload for similarity search queries."""
+
+    query: str = Field(..., description="Natural language question to search against the knowledge base.")
+    top_k: int = Field(5, description="Number of results to return.")
+
+
+class QueryResult(BaseModel):
+    """Response schema for similarity search results."""
+
+    content: str
+    score: float
+    metadata: Dict[str, Any]
+
+
+class QueryResponse(BaseModel):
+    """Response payload containing ranked document chunks."""
+
+    results: List[QueryResult]

--- a/app/text_extraction.py
+++ b/app/text_extraction.py
@@ -1,0 +1,99 @@
+"""Utilities for extracting and chunking text from various document formats."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+import importlib
+
+from . import config
+
+
+class UnsupportedDocumentTypeError(ValueError):
+    """Raised when attempting to parse an unsupported document type."""
+
+
+def extract_text_from_pdf(path: Path) -> str:
+    """Extract text content from a PDF file using ``PyPDF2``.
+
+    Parameters
+    ----------
+    path:
+        Path to the PDF file to extract.
+    """
+    pypdf2 = importlib.import_module("PyPDF2")
+    reader = pypdf2.PdfReader(str(path))
+    parts: List[str] = []
+    for page in reader.pages:
+        page_text = page.extract_text() or ""
+        parts.append(page_text)
+    return "\n".join(parts)
+
+
+def extract_text_from_docx(path: Path) -> str:
+    """Extract text from a Microsoft Word document using ``python-docx``."""
+    docx = importlib.import_module("docx")
+    document = docx.Document(str(path))
+    parts = [paragraph.text for paragraph in document.paragraphs if paragraph.text]
+    return "\n".join(parts)
+
+
+def extract_text_from_txt(path: Path) -> str:
+    """Read text content from a plain text file."""
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+EXTRACTION_FUNCTIONS = {
+    ".pdf": extract_text_from_pdf,
+    ".docx": extract_text_from_docx,
+    ".txt": extract_text_from_txt,
+}
+
+
+def extract_text(path: Path) -> str:
+    """Dispatch to the appropriate extractor based on file extension."""
+    suffix = path.suffix.lower()
+    if suffix not in EXTRACTION_FUNCTIONS:
+        raise UnsupportedDocumentTypeError(f"Unsupported document type: {suffix}")
+    return EXTRACTION_FUNCTIONS[suffix](path)
+
+
+def chunk_text(
+    text: str,
+    *,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
+) -> Iterable[str]:
+    """Yield text chunks of approximately ``chunk_size`` characters.
+
+    Parameters
+    ----------
+    text:
+        Input text to chunk.
+    chunk_size:
+        Maximum number of characters per chunk. Defaults to ``config.CHUNK_SIZE``.
+    chunk_overlap:
+        Number of overlapping characters between consecutive chunks. Defaults to
+        ``config.CHUNK_OVERLAP``.
+    """
+    if not text:
+        return []
+
+    size = chunk_size or config.CHUNK_SIZE
+    overlap = chunk_overlap or config.CHUNK_OVERLAP
+    if size <= overlap:
+        raise ValueError("chunk_size must be greater than chunk_overlap")
+
+    clean_text = text.replace("\r", " ").strip()
+    if not clean_text:
+        return []
+
+    chunks: List[str] = []
+    start = 0
+    text_length = len(clean_text)
+    while start < text_length:
+        end = min(start + size, text_length)
+        chunk = clean_text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        start += size - overlap
+    return chunks

--- a/app/vector_store.py
+++ b/app/vector_store.py
@@ -1,0 +1,105 @@
+"""FAISS-based vector store management."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Sequence
+
+import faiss
+import numpy as np
+
+from .models import DocumentChunk
+
+
+class VectorStoreError(RuntimeError):
+    """Raised when interacting with the FAISS vector store fails."""
+
+
+class FaissVectorStore:
+    """Wrapper around a FAISS index with JSON metadata persistence."""
+
+    def __init__(self, index_path: Path, metadata_path: Path, dimension: int) -> None:
+        self.index_path = Path(index_path)
+        self.metadata_path = Path(metadata_path)
+        self.dimension = dimension
+        self.index = self._load_index()
+        self.metadata: List[dict] = self._load_metadata()
+        if self.index.ntotal != len(self.metadata):
+            # Align metadata with index size by trimming excess entries.
+            min_size = min(self.index.ntotal, len(self.metadata))
+            if self.index.ntotal > min_size:
+                self._shrink_index(min_size)
+            self.metadata = self.metadata[:min_size]
+            self._save_metadata()
+
+    def _load_index(self) -> faiss.Index:
+        if self.index_path.exists():
+            return faiss.read_index(str(self.index_path))
+        return faiss.IndexFlatIP(self.dimension)
+
+    def _shrink_index(self, size: int) -> None:
+        if size == self.index.ntotal:
+            return
+        xb = faiss.vector_to_array(self.index.xb)
+        xb = xb.reshape(self.index.ntotal, self.dimension)[:size]
+        new_index = faiss.IndexFlatIP(self.dimension)
+        new_index.add(xb)
+        self.index = new_index
+        self._save_index()
+
+    def _load_metadata(self) -> List[dict]:
+        if not self.metadata_path.exists():
+            return []
+        with self.metadata_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _save_index(self) -> None:
+        self.index_path.parent.mkdir(parents=True, exist_ok=True)
+        faiss.write_index(self.index, str(self.index_path))
+
+    def _save_metadata(self) -> None:
+        self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.metadata_path.open("w", encoding="utf-8") as f:
+            json.dump(self.metadata, f, ensure_ascii=False, indent=2)
+
+    def add_documents(self, embeddings: np.ndarray, chunks: Sequence[DocumentChunk]) -> None:
+        if embeddings.size == 0 or not chunks:
+            return
+        if embeddings.shape[1] != self.dimension:
+            raise VectorStoreError("Embedding dimensionality does not match the index.")
+        if embeddings.shape[0] != len(chunks):
+            raise VectorStoreError("Number of embeddings must equal number of document chunks.")
+
+        records = [
+            {
+                "content": chunk.content,
+                "metadata": chunk.metadata,
+            }
+            for chunk in chunks
+        ]
+
+        self.index.add(embeddings)
+        self.metadata.extend(records)
+        self._save_index()
+        self._save_metadata()
+
+    def search(self, query_embedding: np.ndarray, top_k: int) -> List[dict]:
+        if self.index.ntotal == 0:
+            return []
+        query = np.asarray([query_embedding], dtype="float32")
+        top_k = max(1, min(top_k, self.index.ntotal))
+        scores, indices = self.index.search(query, top_k)
+        results: List[dict] = []
+        for score, idx in zip(scores[0], indices[0]):
+            if idx == -1 or idx >= len(self.metadata):
+                continue
+            record = dict(self.metadata[idx])
+            record["score"] = float(score)
+            results.append(record)
+        return results
+
+
+def get_vector_store(dimension: int) -> FaissVectorStore:
+    from . import config
+
+    return FaissVectorStore(config.FAISS_INDEX_PATH, config.METADATA_PATH, dimension)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn[standard]
+sentence-transformers
+faiss-cpu
+PyPDF2
+python-docx
+google-api-python-client
+google-auth
+google-auth-httplib2
+numpy


### PR DESCRIPTION
## Summary
- implement a FastAPI research assistant application with Google Drive ingestion, semantic query endpoint, and placeholder routes for future Notion/Canva support
- add text extraction helpers for PDF, DOCX, and TXT along with embedding and FAISS index management utilities
- define project dependencies and ignore transient artifacts

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c963d6e0f0832ba8f6d9da7bab54a9